### PR TITLE
Prevent loading on Forge servers

### DIFF
--- a/src/main/java/xyz/trivaxy/tia/TiaMod.java
+++ b/src/main/java/xyz/trivaxy/tia/TiaMod.java
@@ -9,6 +9,7 @@ import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.slf4j.Logger;
 
 @Mod(TiaMod.MODID)
@@ -21,6 +22,11 @@ public class TiaMod
 
     public TiaMod()
     {
+        if (FMLEnvironment.dist.isDedicatedServer()) {
+            LOGGER.info("TIA is a client-side mod and cannot be loaded on a dedicated server.");
+            return;
+        }
+
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         MinecraftForge.EVENT_BUS.register(this);
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, TiaConfig.SPEC, MODID + ".toml");

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -38,7 +38,7 @@ authors="Trivaxy" #optional
 # IGNORE_ALL_VERSION means that your mod will not cause a red X if it's present on the client or the server. This is a special case and should only be used if your mod has no server component.
 # NONE means that no display test is set on your mod. You need to do this yourself, see IExtensionPoint.DisplayTest for more information. You can define any scheme you wish with this value.
 # IMPORTANT NOTE: this is NOT an instruction as to which environments (CLIENT or DEDICATED SERVER) your mod loads on. Your mod should load (and maybe do nothing!) whereever it finds itself.
-#displayTest="MATCH_VERSION" # MATCH_VERSION is the default if nothing is specified (#optional)
+displayTest="IGNORE_ALL_VERSION"
 
 # The description text for the mod (multi line!) (#mandatory)
 description='''


### PR DESCRIPTION
Since TIA is a client-side mod, it should not be used on servers.
Installing it on a Forge server anyway currently prevents players from moving items in their inventory and spams a lot of errors.
The Fabric versions do not have this problem.

This PR prevents TIA from registering its event listener on a dedicated server and also disables the server list warning if the mod is not installed in the same version on the server and client.

Here's an [example log](https://mclo.gs/BE8VfKy) of what previously happened when running TIA on a server.
This [Forge documentation](https://docs.minecraftforge.net/en/1.20.x/concepts/sides/) for sides describes the features I used.

I targeted the 1.19 branch with this PR since it seems like that is the base branch for all other versions, which should make merging these changes into all versions easier.
